### PR TITLE
Integrate OPERANDI with OLA-HDS

### DIFF
--- a/src/service_broker/service_broker/nextflow.py
+++ b/src/service_broker/service_broker/nextflow.py
@@ -11,6 +11,11 @@ def build_nf_command(nf_script_path, workspace_dir):
     nf_command += f" --volume_dir {workspace_dir}"
     # nf_command += f" --workspace {workspace_dir}/"
     # nf_command += f" --mets {workspace_dir}/mets.xml"
+    # TODO: read user and pw from file or env. Leave blank skips storing in olahd
+    nf_command += " --olahd_username admin"
+    nf_command += ' --olahd_endpoint "http://141.5.104.244/api"'
+    nf_command += " --olahd_password JW24G.xR"
+    nf_command += " --nein oder"
     nf_command += " -with-report"  # produce report.html
     return nf_command
 

--- a/src/service_broker/service_broker/nextflow.py
+++ b/src/service_broker/service_broker/nextflow.py
@@ -15,7 +15,6 @@ def build_nf_command(nf_script_path, workspace_dir):
     nf_command += " --olahd_username admin"
     nf_command += ' --olahd_endpoint "http://141.5.104.244/api"'
     nf_command += " --olahd_password JW24G.xR"
-    nf_command += " --nein oder"
     nf_command += " -with-report"  # produce report.html
     return nf_command
 

--- a/src/service_broker/service_broker/nextflow.py
+++ b/src/service_broker/service_broker/nextflow.py
@@ -2,7 +2,7 @@ import subprocess
 import shlex
 
 
-def build_nf_command(nf_script_path, workspace_dir):
+def build_nf_command(nf_script_path, workspace_dir, save_to_olahd=False):
     nf_command = "nextflow -bg"  # -bg - run in the background
     nf_command += f" run {nf_script_path}"
     # When running an OCR-D docker container
@@ -11,10 +11,11 @@ def build_nf_command(nf_script_path, workspace_dir):
     nf_command += f" --volume_dir {workspace_dir}"
     # nf_command += f" --workspace {workspace_dir}/"
     # nf_command += f" --mets {workspace_dir}/mets.xml"
-    # TODO: read user and pw from file or env. Leave blank skips storing in olahd
-    nf_command += " --olahd_username admin"
-    nf_command += ' --olahd_endpoint "http://141.5.104.244/api"'
-    nf_command += " --olahd_password JW24G.xR"
+    if save_to_olahd:
+        # TODO: read user and pw from file or env. Leave blank skips storing in olahd
+        nf_command += " --olahd_username admin"
+        nf_command += ' --olahd_endpoint "http://141.5.104.244/api"'
+        nf_command += " --olahd_password JW24G.xR"
     nf_command += " -with-report"  # produce report.html
     return nf_command
 

--- a/src/service_broker/service_broker/nextflow/scripts/local_nextflow.nf
+++ b/src/service_broker/service_broker/nextflow/scripts/local_nextflow.nf
@@ -7,6 +7,9 @@ params.mets = "$projectDir/ocrd-workspace/mets.xml"
 params.file_group = "DEFAULT"
 params.reads = "$projectDir/ocrd-workspace/DEFAULT"
 params.volume_dir = "null"
+params.olahd_endpoint = ""
+params.olahd_username = ""
+params.olahd_password = ""
 
 // nextflow run <my script> --volume_dir TEMPDIR
 // Then, the parameter is accessed with: params.tempdir
@@ -19,6 +22,7 @@ log.info """\
   mets          : ${params.mets}
   file_group    : ${params.file_group}
   volume_dir    : ${params.volume_dir}
+  olahd_username: ${params.olahd_username}
   """
   .stripIndent()
 
@@ -46,12 +50,34 @@ process ocrd_cis_ocropy_binarize {
   echo true
 
   input:
-    path mets_file 
+    path mets_file
     path dir_name
-  
+  output:
+    path dir_name
+
   script:
   """
   docker run --rm -v ${params.volume_dir}:/data -w /data -- ocrd/all:maximum ocrd-cis-ocropy-binarize -m ${mets_file} -I ${dir_name} -O "OCR-D-BIN"
+  """
+}
+
+process save_to_olahd {
+  // limit instances to 1
+  // (force to run sequentially)
+  maxForks 1
+  echo true
+
+  input:
+    path mets_file
+    // variable only needed to cause waiting for the completition of other processors
+    path dir_name
+    val olahd_endpoint
+    val olahd_username
+    val olahd_password
+
+  script:
+  """
+  docker run --rm -v ${params.volume_dir}:/data -w /data -- ocrd/all:maximum ocrd-olahd-client -m ${mets_file} -p '{"endpoint": "${olahd_endpoint}", "username": "${olahd_username}", "password": "${olahd_password}"}'
   """
 }
 
@@ -62,5 +88,6 @@ workflow {
     download_workspace(params.mets, params.file_group)
     input_dir_ch = Channel.fromPath(params.reads, type: 'dir')
     ocrd_cis_ocropy_binarize(params.mets, input_dir_ch)
-    
+    if (params.olahd_username)
+        save_to_olahd(params.mets, ocrd_cis_ocropy_binarize.out, params.olahd_endpoint, params.olahd_username, params.olahd_password)
 }

--- a/src/service_broker/service_broker/nextflow/scripts/local_nextflow.nf
+++ b/src/service_broker/service_broker/nextflow/scripts/local_nextflow.nf
@@ -88,6 +88,6 @@ workflow {
     download_workspace(params.mets, params.file_group)
     input_dir_ch = Channel.fromPath(params.reads, type: 'dir')
     ocrd_cis_ocropy_binarize(params.mets, input_dir_ch)
-    if (params.olahd_username)
+    if (params.olahd_endpoint && params.olahd_username && params.olahd_password)
         save_to_olahd(params.mets, ocrd_cis_ocropy_binarize.out, params.olahd_endpoint, params.olahd_username, params.olahd_password)
 }


### PR DESCRIPTION
This is a draft pull request to show how the ocrd_olahd_client-processor could be used in operandi.

It is still open how to provide the password to nextflow. Currently it is hard-coded, this is ok for the beta-release but I think the credentials should not be hard-coded if we had a productive instance. They should neither be stored in the workflow script because this files are readable. So I think it would be best to store them in a config file and/or environment variable and read them from operandi on demand.
Because of that I didn't write them in the nextflow-script but into nextflow.py for now to be replaced later.