### PR TITLE
Update ola-hd upload functionality

### DIFF
--- a/src/server/operandi_server/models/__init__.py
+++ b/src/server/operandi_server/models/__init__.py
@@ -1,4 +1,5 @@
 __all__ = [
+    "OlahdUploadArguments"
     "PYDiscovery",
     "PYUserAction",
     "PYUserInfo",
@@ -10,7 +11,7 @@ __all__ = [
     "WorkspaceRsrc"
 ]
 
-from .base import Resource, SbatchArguments, WorkflowArguments
+from .base import Resource, SbatchArguments, WorkflowArguments, OlahdUploadArguments
 from .discovery import PYDiscovery
 from .user import PYUserAction, PYUserInfo
 from .workflow import WorkflowRsrc, WorkflowJobRsrc

--- a/src/server/operandi_server/models/base.py
+++ b/src/server/operandi_server/models/base.py
@@ -32,3 +32,11 @@ class SbatchArguments(BaseModel):
 
     class Config:
         allow_population_by_field_name = True
+
+class OlahdUploadArguments(BaseModel):
+    username: str
+    password: str
+    endpoint: str
+
+    class Config:
+        allow_population_by_field_name = True

--- a/src/utils/operandi_utils/constants.py
+++ b/src/utils/operandi_utils/constants.py
@@ -19,9 +19,6 @@ __all__ = [
     "LOG_LEVEL_WORKER",
     "MODULE_TYPES",
     "OCRD_PROCESSOR_EXECUTABLE_TO_IMAGE",
-    "OLA_HD_BAG_ENDPOINT",
-    "OLA_HD_USER",
-    "OLA_HD_PASSWORD",
     "OPERANDI_VERSION",
     "ServerApiTag",
     "StateJob",
@@ -40,14 +37,6 @@ LOG_LEVEL_RMQ_CONSUMER: str = "INFO"
 LOG_LEVEL_RMQ_PUBLISHER: str = "INFO"
 
 MODULE_TYPES = ["server", "harvester", "broker", "worker"]
-
-# Notes left by @joschrew
-# OLA-HD development instance, reachable only when connected to GÖNET
-OLA_HD_BAG_ENDPOINT = "http://141.5.99.53/api/bag"
-# The credentials are already publicly available inside the OLA-HD repo
-# Ignore docker warnings about exposed credentials
-OLA_HD_USER = "admin"
-OLA_HD_PASSWORD = "JW24G.xR"
 
 OPERANDI_VERSION = get_distribution("operandi_utils").version
 

--- a/src/utils/operandi_utils/utils.py
+++ b/src/utils/operandi_utils/utils.py
@@ -13,8 +13,6 @@ from uuid import uuid4
 
 from ocrd_utils import initLogging
 
-from .constants import OLA_HD_BAG_ENDPOINT, OLA_HD_USER, OLA_HD_PASSWORD
-
 
 logging_initialized = False
 
@@ -118,11 +116,10 @@ def unpack_zip_archive(source, destination) -> None:
     unpack_archive(filename=source, extract_dir=destination)
 
 
-# TODO: Conceptual implementation, not tested in any way yet
-def send_bag_to_ola_hd(path_to_bag) -> str:
+def send_bag_to_ola_hd(path_to_bag, username, password, endpoint) -> str:
     ola_hd_files = {"file": open(path_to_bag, "rb")}
-    ola_hd_auth = (OLA_HD_USER, OLA_HD_PASSWORD)
-    ola_hd_response = post(url=OLA_HD_BAG_ENDPOINT, files=ola_hd_files, data={"isGt": False}, auth=ola_hd_auth)
+    ola_hd_auth = (username, password)
+    ola_hd_response = post(url=endpoint, files=ola_hd_files, auth=ola_hd_auth)
     if ola_hd_response.status_code >= 400:
         ola_hd_response.raise_for_status()
     return ola_hd_response.json()["pid"]


### PR DESCRIPTION
With this change the access parameters for olahd can be provided by the client. This way operandi doesn't need to know the credentials and which olahd instance to use. These changes worked on my machine.