### PR TITLE
Olahd upload error-code forwarding

### DIFF
--- a/src/server/operandi_server/routers/workspace.py
+++ b/src/server/operandi_server/routers/workspace.py
@@ -325,7 +325,11 @@ class RouterWorkspace:
         except Exception as error:
             message = "Failed to send bag to Ola-HD service"
             self.logger.error(f"{message}, error: {error}")
-            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=message)
+            try:
+                response_status_code = error.response.status_code
+            except AttributeError:
+                response_status_code = status.HTTP_422_UNPROCESSABLE_ENTITY
+            raise HTTPException(status_code=response_status_code, detail=message)
 
         response_message = {
             "message": f"Workspace bag of id: {workspace_id} was pushed to the Ola-HD service",


### PR DESCRIPTION
When the olahd upload fails the error code may give information about what went wrong. I think I forgot this change when I made the original PR #27.
It's not urgent for me it would be enough if it was included in some future release at some point